### PR TITLE
Fix parsing of hunk headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ impl PatchedFile {
             .unwrap();
         let source_length = header_info
             .name("source_length")
-            .map_or("0", |s| s.as_str())
+            .map_or("1", |s| s.as_str())
             .parse::<usize>()
             .unwrap();
         let target_start = header_info
@@ -394,7 +394,7 @@ impl PatchedFile {
             .unwrap();
         let target_length = header_info
             .name("target_length")
-            .map_or("0", |s| s.as_str())
+            .map_or("1", |s| s.as_str())
             .parse::<usize>()
             .unwrap();
         let section_header = header_info

--- a/tests/test_patchset.rs
+++ b/tests/test_patchset.rs
@@ -342,6 +342,13 @@ fn test_single_line_diff() {
         assert_eq!("sample.txt", added_files[0].path());
         assert_eq!(1, added_files[0].added());
         assert_eq!(0, added_files[0].removed());
+
+        let hunks = added_files[0].hunks();
+        assert_eq!(1, hunks.len());
+        assert_eq!(0, hunks[0].source_start);
+        assert_eq!(0, hunks[0].source_length);
+        assert_eq!(1, hunks[0].target_start);
+        assert_eq!(1, hunks[0].target_length);
     }
     {
         let buf = include_str!("fixtures/sample5.diff");


### PR DESCRIPTION
# Summary

The present implementation of hunk headers parsing assumes that the source and target lengths of a hunk are 0 when these are not specified.

This is incorrect. The unidiff spec omits the length of a hunk when this is 1, not 0: https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html

This PR updates the parsing logic to default missing source and target lengths in a hunk header to 1 and adds a test that exercises this behaviour.

# Tests

Unit tests pass: `cargo test`